### PR TITLE
Step 4

### DIFF
--- a/src/main/kotlin/org/example/cleanarchitecturelecture/application/lecture/LectureService.kt
+++ b/src/main/kotlin/org/example/cleanarchitecturelecture/application/lecture/LectureService.kt
@@ -22,12 +22,14 @@ class LectureService(
         participant: User,
         command: EnrollLectureCommand,
     ) {
+        val scheduleParticipantCount =
+            lectureParticipantCountRepository.findByScheduleIdWithLock(command.scheduleId)
+                ?: throw IllegalArgumentException(ErrorMessage.LECTURE_SCHEDULE_NOT_FOUND.message)
+
         val enrolledSchedule =
             lectureScheduleRepository.findById(command.scheduleId)
                 ?: throw IllegalArgumentException(ErrorMessage.LECTURE_SCHEDULE_NOT_FOUND.message)
         require(enrolledSchedule.lecture.id == command.lectureId) { ErrorMessage.LECTURE_SCHEDULE_NOT_BELONG_TO_LECTURE.message }
-
-        val scheduleParticipantCount = lectureParticipantCountRepository.getByScheduleIdWithLock(enrolledSchedule.id)
 
         enrolledSchedule.enroll(participant)
         scheduleParticipantCount.increment()

--- a/src/main/kotlin/org/example/cleanarchitecturelecture/application/lecture/LectureService.kt
+++ b/src/main/kotlin/org/example/cleanarchitecturelecture/application/lecture/LectureService.kt
@@ -26,9 +26,7 @@ class LectureService(
             lectureParticipantCountRepository.findByScheduleIdWithLock(command.scheduleId)
                 ?: throw IllegalArgumentException(ErrorMessage.LECTURE_SCHEDULE_NOT_FOUND.message)
 
-        val enrolledSchedule =
-            lectureScheduleRepository.findById(command.scheduleId)
-                ?: throw IllegalArgumentException(ErrorMessage.LECTURE_SCHEDULE_NOT_FOUND.message)
+        val enrolledSchedule = scheduleParticipantCount.schedule
         require(enrolledSchedule.lecture.id == command.lectureId) { ErrorMessage.LECTURE_SCHEDULE_NOT_BELONG_TO_LECTURE.message }
 
         enrolledSchedule.enroll(participant)

--- a/src/main/kotlin/org/example/cleanarchitecturelecture/common/exception/ErrorMessage.kt
+++ b/src/main/kotlin/org/example/cleanarchitecturelecture/common/exception/ErrorMessage.kt
@@ -11,6 +11,7 @@ enum class ErrorMessage(
     LECTURE_SCHEDULE_ALREADY_STARTED("이미 시작된 강의 일정입니다."),
     TEACHER_CANNOT_BE_PARTICIPANT("강사는 수강할 수 없습니다."),
     LECTURE_PARTICIPANT_COUNT_EXCEEDED("수강 인원이 초과되었습니다."),
+    LECTURE_PARTICIPANT_ALREADY_ENROLLED("이미 수강 신청한 강의입니다."),
 
     LECTURE_END_DATE_BEFORE_START_DATE("특강 종료 시간이 시작 시간보다 빠릅니다."),
     QUERY_SIZE_OUT_OF_RANGE("조회 범위를 벗어났습니다. 조회는 1 ~ 100개 가능합니다."),

--- a/src/main/kotlin/org/example/cleanarchitecturelecture/domain/lecture/Lecture.kt
+++ b/src/main/kotlin/org/example/cleanarchitecturelecture/domain/lecture/Lecture.kt
@@ -15,7 +15,7 @@ class Lecture(
     @Comment("특강 내용")
     val content: String,
     @ManyToOne
-    @JoinColumn(name = "user_id")
+    @JoinColumn(name = "user_id", nullable = false)
     @Comment("특강 강사")
     val teacher: User,
     @Id

--- a/src/main/kotlin/org/example/cleanarchitecturelecture/domain/lecture/LectureParticipant.kt
+++ b/src/main/kotlin/org/example/cleanarchitecturelecture/domain/lecture/LectureParticipant.kt
@@ -6,7 +6,12 @@ import org.example.cleanarchitecturelecture.domain.user.User
 import org.hibernate.annotations.Comment
 
 @Entity
-@Table(name = "lecture_participants")
+@Table(
+    name = "lecture_participants",
+    uniqueConstraints = [
+        UniqueConstraint(name = "unique_lecture_participant_schedule_user", columnNames = ["user_id", "schedule_id"]),
+    ],
+)
 class LectureParticipant(
     @ManyToOne
     @JoinColumn(name = "schedule_id")

--- a/src/main/kotlin/org/example/cleanarchitecturelecture/domain/lecture/LectureParticipant.kt
+++ b/src/main/kotlin/org/example/cleanarchitecturelecture/domain/lecture/LectureParticipant.kt
@@ -14,11 +14,11 @@ import org.hibernate.annotations.Comment
 )
 class LectureParticipant(
     @ManyToOne
-    @JoinColumn(name = "schedule_id")
+    @JoinColumn(name = "schedule_id", nullable = false)
     @Comment("특강 일정")
     val schedule: LectureSchedule,
     @ManyToOne
-    @JoinColumn(name = "user_id")
+    @JoinColumn(name = "user_id", nullable = false)
     @Comment("특강 참가자")
     val participant: User,
     @Id

--- a/src/main/kotlin/org/example/cleanarchitecturelecture/domain/lecture/LectureParticipantCount.kt
+++ b/src/main/kotlin/org/example/cleanarchitecturelecture/domain/lecture/LectureParticipantCount.kt
@@ -9,7 +9,7 @@ import org.hibernate.annotations.Comment
 @Table(name = "lecture_participant_counts")
 class LectureParticipantCount(
     @OneToOne
-    @JoinColumn(name = "schedule_id")
+    @JoinColumn(name = "schedule_id", nullable = false)
     @Comment("특강 일정")
     val schedule: LectureSchedule,
     @Column(name = "count", nullable = false)

--- a/src/main/kotlin/org/example/cleanarchitecturelecture/domain/lecture/LectureParticipantCountRepository.kt
+++ b/src/main/kotlin/org/example/cleanarchitecturelecture/domain/lecture/LectureParticipantCountRepository.kt
@@ -1,5 +1,5 @@
 package org.example.cleanarchitecturelecture.domain.lecture
 
 interface LectureParticipantCountRepository {
-    fun getByScheduleIdWithLock(scheduleId: Long): LectureParticipantCount
+    fun findByScheduleIdWithLock(scheduleId: Long): LectureParticipantCount?
 }

--- a/src/main/kotlin/org/example/cleanarchitecturelecture/domain/lecture/LectureSchedule.kt
+++ b/src/main/kotlin/org/example/cleanarchitecturelecture/domain/lecture/LectureSchedule.kt
@@ -30,6 +30,7 @@ class LectureSchedule(
     fun enroll(participant: User) {
         require(lecture.isNotTeacher(participant)) { ErrorMessage.TEACHER_CANNOT_BE_PARTICIPANT.message }
         require(startedAt.isAfter(LocalDateTime.now())) { ErrorMessage.LECTURE_SCHEDULE_ALREADY_STARTED.message }
+        require(participants.none { it.participant == participant }) { ErrorMessage.LECTURE_PARTICIPANT_ALREADY_ENROLLED.message }
 
         participants.add(LectureParticipant(this, participant))
     }

--- a/src/main/kotlin/org/example/cleanarchitecturelecture/domain/lecture/LectureSchedule.kt
+++ b/src/main/kotlin/org/example/cleanarchitecturelecture/domain/lecture/LectureSchedule.kt
@@ -17,10 +17,10 @@ class LectureSchedule(
     @Comment("특강 종료 시간")
     val endedAt: LocalDateTime,
     @ManyToOne
-    @JoinColumn(name = "lecture_id")
+    @JoinColumn(name = "lecture_id", nullable = false)
     @Comment("특강")
     val lecture: Lecture,
-    @OneToMany(mappedBy = "schedule", cascade = [CascadeType.ALL], fetch = FetchType.LAZY)
+    @OneToMany(mappedBy = "schedule", cascade = [CascadeType.ALL], fetch = FetchType.EAGER)
     @Comment("특강 참가자 목록")
     val participants: MutableList<LectureParticipant> = mutableListOf(),
     @Id

--- a/src/main/kotlin/org/example/cleanarchitecturelecture/infrastructure/persistence/lecture/DataJpaLectureParticipantCountRepository.kt
+++ b/src/main/kotlin/org/example/cleanarchitecturelecture/infrastructure/persistence/lecture/DataJpaLectureParticipantCountRepository.kt
@@ -7,5 +7,5 @@ import org.springframework.data.jpa.repository.Lock
 
 interface DataJpaLectureParticipantCountRepository : JpaRepository<LectureParticipantCount, Long> {
     @Lock(LockModeType.PESSIMISTIC_WRITE)
-    fun getByScheduleId(scheduleId: Long): LectureParticipantCount
+    fun findByScheduleId(scheduleId: Long): LectureParticipantCount?
 }

--- a/src/main/kotlin/org/example/cleanarchitecturelecture/infrastructure/persistence/lecture/DataJpaLectureParticipantCountRepository.kt
+++ b/src/main/kotlin/org/example/cleanarchitecturelecture/infrastructure/persistence/lecture/DataJpaLectureParticipantCountRepository.kt
@@ -4,8 +4,16 @@ import jakarta.persistence.LockModeType
 import org.example.cleanarchitecturelecture.domain.lecture.LectureParticipantCount
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Lock
+import org.springframework.data.jpa.repository.Query
 
 interface DataJpaLectureParticipantCountRepository : JpaRepository<LectureParticipantCount, Long> {
     @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query(
+        """
+                SELECT lpc FROM LectureParticipantCount lpc 
+                JOIN lpc.schedule s
+                WHERE s.id = :scheduleId
+        """
+    )
     fun findByScheduleId(scheduleId: Long): LectureParticipantCount?
 }

--- a/src/main/kotlin/org/example/cleanarchitecturelecture/infrastructure/persistence/lecture/JpaLectureParticipantCountRepository.kt
+++ b/src/main/kotlin/org/example/cleanarchitecturelecture/infrastructure/persistence/lecture/JpaLectureParticipantCountRepository.kt
@@ -8,6 +8,6 @@ import org.springframework.stereotype.Repository
 class JpaLectureParticipantCountRepository(
     private val dataJpaLectureParticipantCountRepository: DataJpaLectureParticipantCountRepository,
 ) : LectureParticipantCountRepository {
-    override fun getByScheduleIdWithLock(scheduleId: Long): LectureParticipantCount =
-        dataJpaLectureParticipantCountRepository.getByScheduleId(scheduleId)
+    override fun findByScheduleIdWithLock(scheduleId: Long): LectureParticipantCount? =
+        dataJpaLectureParticipantCountRepository.findByScheduleId(scheduleId)
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -9,8 +9,10 @@ spring:
     hibernate:
       ddl-auto: create-drop
     properties:
-      format_sql: true
-      use_sql_comments: true
+      hibernate:
+        format_sql: true
+        use_sql_comments: true
+
     show-sql: true
     open-in-view: false
     defer-datasource-initialization: true

--- a/src/test/kotlin/org/example/cleanarchitecturelecture/TestcontainersConfiguration.kt
+++ b/src/test/kotlin/org/example/cleanarchitecturelecture/TestcontainersConfiguration.kt
@@ -8,7 +8,17 @@ import org.testcontainers.utility.DockerImageName
 
 @TestConfiguration(proxyBeanMethods = false)
 class TestcontainersConfiguration {
+    companion object {
+        @JvmStatic
+        val mysqlContainer: MySQLContainer<*> by lazy {
+            MySQLContainer(DockerImageName.parse("mysql:8.0.32")).apply {
+                withReuse(true)
+                start()
+            }
+        }
+    }
+
     @Bean
     @ServiceConnection
-    fun mysqlContainer(): MySQLContainer<*> = MySQLContainer(DockerImageName.parse("mysql:8.0.32"))
+    fun mysqlContainer(): MySQLContainer<*> = mysqlContainer
 }

--- a/src/test/kotlin/org/example/cleanarchitecturelecture/application/lecture/IntegrationLectureServiceTest.kt
+++ b/src/test/kotlin/org/example/cleanarchitecturelecture/application/lecture/IntegrationLectureServiceTest.kt
@@ -44,5 +44,26 @@ class IntegrationLectureServiceTest {
             assertThat(successCount).isEqualTo(30)
             assertThat(failCount).isEqualTo(10)
         }
+
+        @Test
+        @DisplayName("[실패] 동일한 유저 정보로 동시에 5번 신청했을 때 1번만 성공한다.")
+        fun testEnrollWithSameUser() {
+            val count = 5
+            val requests =
+                (1 until count.toLong() + 1)
+                    .map { LectureFixture.createEnrollLectureCommand(2, 3, 1) }
+
+            val result =
+                ConcurrentTestHelper.executeAsyncTasksWithData(count, requests) {
+                    val participant = UserFixture.create(id = 1)
+                    lectureService.enroll(participant, it)
+                }
+
+            val successCount = result.count { it }
+            val failCount = result.count { !it }
+
+            assertThat(successCount).isEqualTo(1)
+            assertThat(failCount).isEqualTo(4)
+        }
     }
 }

--- a/src/test/kotlin/org/example/cleanarchitecturelecture/application/lecture/LectureServiceTest.kt
+++ b/src/test/kotlin/org/example/cleanarchitecturelecture/application/lecture/LectureServiceTest.kt
@@ -36,7 +36,7 @@ class LectureServiceTest {
             val command = LectureFixture.createEnrollLectureCommand()
             val notExistsScheduleId = command.scheduleId
 
-            every { lectureScheduleRepository.findById(notExistsScheduleId) } returns null
+            every { lectureParticipantCountRepository.findByScheduleIdWithLock(notExistsScheduleId) } returns null
 
             assertThatThrownBy { lectureService.enroll(participant, command) }
                 .isInstanceOf(IllegalArgumentException::class.java)
@@ -50,6 +50,8 @@ class LectureServiceTest {
             val command = LectureFixture.createEnrollLectureCommand(lectureId = 99999999)
             val notBelongToLectureScheduleId = command.scheduleId
 
+            every { lectureParticipantCountRepository.findByScheduleIdWithLock(notBelongToLectureScheduleId) } returns
+                LectureFixture.createParticipantCount()
             every { lectureScheduleRepository.findById(notBelongToLectureScheduleId) } returns LectureFixture.createSchedule()
 
             assertThatThrownBy { lectureService.enroll(participant, command) }

--- a/src/test/kotlin/org/example/cleanarchitecturelecture/domain/lecture/LectureScheduleTest.kt
+++ b/src/test/kotlin/org/example/cleanarchitecturelecture/domain/lecture/LectureScheduleTest.kt
@@ -51,5 +51,18 @@ class LectureScheduleTest {
                 .isInstanceOf(IllegalArgumentException::class.java)
                 .hasMessage(ErrorMessage.LECTURE_SCHEDULE_ALREADY_STARTED.message)
         }
+
+        @Test
+        @DisplayName("[실패] 이미 참가 신청한 유저가 다시 참가 신청을 하는 경우 예외가 발생한다.")
+        fun testEnrollWithAlreadyEnrolledParticipant() {
+            val lectureSchedule = LectureFixture.createSchedule()
+            val participant = UserFixture.create(id = 2)
+
+            lectureSchedule.enroll(participant)
+
+            assertThatThrownBy { lectureSchedule.enroll(participant) }
+                .isInstanceOf(IllegalArgumentException::class.java)
+                .hasMessage(ErrorMessage.LECTURE_PARTICIPANT_ALREADY_ENROLLED.message)
+        }
     }
 }

--- a/src/test/kotlin/org/example/cleanarchitecturelecture/stub/lecture/LectureFixture.kt
+++ b/src/test/kotlin/org/example/cleanarchitecturelecture/stub/lecture/LectureFixture.kt
@@ -49,7 +49,7 @@ object LectureFixture {
         )
 
     fun createParticipantCount(
-        id: Long = 0,
+        id: Long = 1L,
         count: Int = 0,
     ): LectureParticipantCount =
         LectureParticipantCount(


### PR DESCRIPTION
### **커밋 링크**
- [♻️ refactor : 동일한 유저 정보로 같은 특강을 신청하는 경우 실패하도록 개선](https://github.com/zxcv9203/clean-architecture-lecture/commit/071441f4a81fd32ddcf1d1022211e28abd9c4624)
  - 동일한 유저 정보로 같은 특강을 신청하는 경우 Count의 비관적 락 이후에 스케줄을 조회하기 때문에 application에 검증 로직을 넣어 동일한 유저가 같은 특강을 신청하지 못하도록 처리했습니다.
-  [♻️ refactor : 유니크 제약 조건을 통해 절대 같은 강의에 동일한 사용자가 들어올 수 없도록 제한](https://github.com/zxcv9203/clean-architecture-lecture/commit/7857289228de60f6b42cdf70e83ca1407f385eea)
  - 애플리케이션 단에서 동일한 유저 정보로 특강을  막았지만 DB 단에서 아예 막아주기 위해 UNIQUE 키 제약조건을 추가했습니다.
- [♻️ refactor : 테스트 컨테이너로 사용되는 DB를 한번만 띄워서 재사용하도록 설정](https://github.com/zxcv9203/clean-architecture-lecture/commit/9e8927ecfdd964107f3268540595ace1f14035f9)
  - 테스트 컨테이너가 스프링 컨텍스트마다 계속 생성되어 테스트 속도가 느려져서 이를 재사용할 수 있도록 static으로 처리
- [♻️ refactor : INNER JOIN으로 가져올 수 있는 엔티티에 대해 INNER JOIN을 사용하도록 옵션 추가 및 쿼리 작성](https://github.com/zxcv9203/clean-architecture-lecture/commit/3b4a4bb7685bd26536c61812a26ec639b376c8fb) 
  - INNER JOIN으로 데이터를 가져올 수 있음에도 전부 LEFT JOIN을 사용하고 있어 명시적으로 INNER JOIN을 사용하도록 유도했습니다.
### **리뷰 포인트(질문)**
- 현재 통합 테스트시에 stub 객체가 너무 많아지다보면 오히려 테스트시에 테스트 로직에 집중하기 어려워지는 것 같아 @Sql 어노테이션으로 미리 더미데이터를 사용하는 방식으로 테스트를 진행해보았습니다. 코치님이 보시기에 어떠신지 의견이 궁금합니다.
  - 어떤게 생성되는지 바로 로직에서 확인할 수 없어 오히려 실수하기 쉬운 구조라고도 생각이 들었습니다 🤔 
- 현재 쿼리 개수를 줄이기 위해 LectureParticipant를 EAGER 패치를 하도록 지정했는데 그랬더니 엄청난 수의 JOIN이 반겨주는 것 같습니다 😂   현재 LectureSchedule 조회시 무조건 LectureParticipant를 사용하기 때문에 EAGER로 변경했는데 이런 경우 LAZY로 두번 조회하는게 나을지 궁금합니다.
  - JOIN이 너무 많아지면 쿼리를 분리한다 같은 기준은 어떻게 잡으면 좋을지 궁금합니다 🤔   
